### PR TITLE
feat: support //go:debug directive

### DIFF
--- a/checkcompilerdirectives/checkcompilerdirectives.go
+++ b/checkcompilerdirectives/checkcompilerdirectives.go
@@ -85,6 +85,7 @@ var known = []string{
 	"cgo_import_static",
 	"cgo_ldflag",
 	"cgo_unsafe_args",
+	"debug",
 	"embed",
 	"generate",
 	"linkname",


### PR DESCRIPTION
This PR adds support for `//go:debug` as described here: https://go.dev/doc/godebug
I realise that https://github.com/leighmcculloch/gocheckcompilerdirectives/pull/3 already adds this but since there still seems to be some unresolved discussion I created this in the hope we can get just this in.